### PR TITLE
fix: all domain parts should not be empty

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -332,6 +332,7 @@ function isCorrectDomain(domain) {
 
   if (
     parts.length < 2 ||
+    parts.some((part) => !part) ||
     (parts[parts.length - 1] &&
       (/_/.test(parts[parts.length - 1]) ||
         !/[a-zA-Z\d]/.test(parts[parts.length - 1]))) ||


### PR DESCRIPTION
"test www." (should not link)
"test www..test.com" (should not link)